### PR TITLE
Correction flux RSS

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -16,7 +16,7 @@
       <itunes:email>sylvain.abelard+zenm4@gmail.com</itunes:email>
     </itunes:owner>
     <itunes:image href="http://www.zenm4.net/img/zenm4.png" />
-    <itunes:category text="Technology">
+    <itunes:category text="Technology"/>
     <pubDate>Sun, 13 Mar 2016 22:36:22 +0100</pubDate>
     <lastBuildDate>Sun, 13 Mar 2016 22:36:22 +0100</lastBuildDate>
     <generator>Jekyll v3.1.2</generator>


### PR DESCRIPTION
Bonjour et merci pour votre podcast !
Pour information, il y a une petite erreur dans le xml de votre flux RSS, et ça pose problème à certains logiciels comme Rhytmnbox qui ne parvient pas à lire le flux.
L'appli Podcast addict y parvient mais indique une erreur, comme Chrome d'ailleurs.

Le souci vient de la balise de fermeture "itunes:category" qui n'existe pas...

Bonne continuation !
Jérémy
